### PR TITLE
Fix custom hover shadow class with Tailwind layer

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -202,16 +202,18 @@ button:active:not(:disabled) {
 }
 
 /* Enhanced card shadows */
-.shadow-beautiful {
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-}
+@layer utilities {
+  .shadow-beautiful {
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  }
 
-.shadow-beautiful-hover {
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-}
+  .shadow-beautiful-hover {
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  }
 
-.shadow-beautiful-lg {
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  .shadow-beautiful-lg {
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  }
 }
 
 /* Beautiful text gradients */


### PR DESCRIPTION
## Summary
- add `@layer utilities` around custom shadow classes so `@apply` can use them

## Testing
- `npm run lint` *(fails: Plus, Clock, Flame unused, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ef2d6261c83338be2ee36cc93f368