### PR TITLE
UI overhaul with modern neutral palette

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Home, Calendar, Flame, Settings, Plus } from 'lucide-react';
+import { Home, Calendar, Flame, Settings } from 'lucide-react';
 import Dashboard from './components/Dashboard';
 import Schedule from './components/Schedule';
 import Streaks from './components/Streaks';
@@ -215,7 +215,7 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">
+    <div className="min-h-screen bg-[#F4F6F8]">
       {/* Main Content */}
       <div className="pb-24">
         {renderContent()}
@@ -225,10 +225,10 @@ function App() {
       <nav className="nav-beautiful px-6 py-4 safe-area-pb">
         <div className="flex justify-around items-center max-w-md mx-auto">
           {[
-            { id: 'dashboard', icon: Home, label: 'Today', gradient: 'from-blue-500 to-blue-600' },
-            { id: 'schedule', icon: Calendar, label: 'Schedule', gradient: 'from-purple-500 to-purple-600' },
-            { id: 'streaks', icon: Flame, label: 'Progress', gradient: 'from-orange-500 to-red-500' },
-            { id: 'settings', icon: Settings, label: 'Settings', gradient: 'from-gray-500 to-gray-600' }
+            { id: 'dashboard', icon: Home, label: 'Today', gradient: 'from-[#007BFF] to-[#0056b3]' },
+            { id: 'schedule', icon: Calendar, label: 'Schedule', gradient: 'from-[#007BFF] to-[#0056b3]' },
+            { id: 'streaks', icon: Flame, label: 'Progress', gradient: 'from-[#007BFF] to-[#0056b3]' },
+            { id: 'settings', icon: Settings, label: 'Settings', gradient: 'from-[#007BFF] to-[#0056b3]' }
           ].map(({ id, icon: Icon, label, gradient }) => (
             <button
               key={id}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Plus, CheckCircle2, Circle, Clock, Timer, Waves, MoreHorizontal, Trash2, RotateCcw, Play, Pause, Sparkles, Target } from 'lucide-react';
+import { CheckCircle2, Circle, Clock, Timer, Waves, MoreHorizontal, Trash2, RotateCcw, Play, Pause, Sparkles, Target } from 'lucide-react';
 import { Task, Settings } from '../types';
 
 interface DashboardProps {
@@ -79,7 +79,7 @@ const Dashboard: React.FC<DashboardProps> = ({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">
+    <div className="min-h-screen bg-[#F4F6F8]">
       <div className="px-4 pt-8 pb-6">
         <div className="max-w-md mx-auto">
           {/* Beautiful Header with Gradient */}
@@ -118,11 +118,13 @@ const Dashboard: React.FC<DashboardProps> = ({
                   </div>
                   <span className="text-sm font-bold text-gradient-primary">{Math.round(progress * 100)}%</span>
                 </div>
-                <div className="progress-beautiful">
-                  <div 
+                <div className="progress-beautiful relative">
+                  <div
                     className="progress-fill"
                     style={{ width: `${progress * 100}%` }}
                   />
+                  <div className="absolute top-0 left-1/4 h-full w-px bg-white/70"></div>
+                  <div className="absolute top-0 left-1/2 h-full w-px bg-white/70"></div>
                 </div>
                 <div className="mt-2 text-xs text-gray-600">
                   Keep going! You're doing great today.
@@ -135,7 +137,7 @@ const Dashboard: React.FC<DashboardProps> = ({
           <div className="mb-8 animate-slide-up">
             <div className="card-beautiful p-8">
               <div className="flex items-center space-x-3 mb-6">
-                <div className="p-2 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full">
+                <div className="p-2 bg-gradient-to-r from-[#007BFF] to-[#0056b3] rounded-full">
                   <Plus size={20} className="text-white" />
                 </div>
                 <h2 className="text-xl font-bold text-gray-900">
@@ -144,24 +146,6 @@ const Dashboard: React.FC<DashboardProps> = ({
               </div>
               
               <form onSubmit={handleSubmit} className="space-y-6">
-                <div className="relative">
-                  <input
-                    type="text"
-                    value={taskInput}
-                    onChange={(e) => setTaskInput(e.target.value)}
-                    placeholder="e.g., Finish homework (45 minutes)"
-                    className="input-beautiful text-base pr-16"
-                    autoFocus
-                  />
-                  <button
-                    type="submit"
-                    disabled={!taskInput.trim()}
-                    className="absolute right-3 top-1/2 transform -translate-y-1/2 p-3 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-xl hover:shadow-beautiful disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300"
-                  >
-                    <Plus size={18} />
-                  </button>
-                </div>
-                
                 <div className="flex items-center space-x-4">
                   <label className="flex items-center space-x-3 cursor-pointer group">
                     <input
@@ -178,6 +162,25 @@ const Dashboard: React.FC<DashboardProps> = ({
                     </div>
                   </label>
                 </div>
+
+                <div className="relative">
+                  <input
+                    type="text"
+                    value={taskInput}
+                    onChange={(e) => setTaskInput(e.target.value)}
+                    placeholder="e.g., Finish homework (45 minutes)"
+                    className="input-beautiful text-base pr-24"
+                    autoFocus
+                  />
+                  <button
+                    type="submit"
+                    disabled={!taskInput.trim()}
+                    className="absolute right-3 top-1/2 transform -translate-y-1/2 px-4 py-2 bg-gradient-to-r from-[#007BFF] to-[#0056b3] text-white rounded-lg hover:shadow-beautiful disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300"
+                  >
+                    Add Task
+                  </button>
+                </div>
+                <p className="text-xs text-gray-500">Press Enter to add</p>
               </form>
             </div>
           </div>
@@ -185,7 +188,7 @@ const Dashboard: React.FC<DashboardProps> = ({
           {/* Beautiful Active Task Widget */}
           {currentActiveTask && (
             <div className="mb-8 animate-scale-in">
-              <div className="bg-gradient-to-r from-blue-500 to-indigo-600 rounded-3xl p-6 text-white shadow-beautiful-lg">
+              <div className="bg-gradient-to-r from-[#007BFF] to-[#0056b3] rounded-lg p-6 text-white shadow-beautiful-lg">
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center space-x-3">
                     <div className="w-3 h-3 bg-white rounded-full animate-pulse-soft"></div>
@@ -203,7 +206,7 @@ const Dashboard: React.FC<DashboardProps> = ({
                   </div>
                   <button
                     onClick={() => onUpdateTaskStatus(currentActiveTask.id, 'not-started')}
-                    className="flex items-center space-x-2 px-4 py-2 bg-white/20 hover:bg-white/30 text-white rounded-xl font-medium transition-all duration-300 backdrop-blur-sm"
+                    className="flex items-center space-x-2 px-4 py-2 bg-white/20 hover:bg-white/30 text-white rounded-lg font-medium transition-all duration-300 backdrop-blur-sm"
                   >
                     <Pause size={16} />
                     <span>Pause</span>
@@ -216,7 +219,7 @@ const Dashboard: React.FC<DashboardProps> = ({
           {/* Beautiful Flexible Tasks Summary */}
           {flexibleTasks.length > 0 && (
             <div className="mb-8 animate-slide-up">
-              <div className="bg-gradient-to-r from-purple-500 to-pink-500 rounded-3xl p-6 text-white shadow-beautiful-lg">
+              <div className="bg-gradient-to-r from-[#00C853] to-[#009624] rounded-lg p-6 text-white shadow-beautiful-lg">
                 <div className="flex items-center space-x-3 mb-3">
                   <Waves size={20} className="text-white" />
                   <h3 className="font-bold text-lg">Flexible Tasks</h3>
@@ -341,12 +344,12 @@ const Dashboard: React.FC<DashboardProps> = ({
                       <div className="relative">
                         <button
                           onClick={() => setActiveTaskMenu(activeTaskMenu === task.id ? null : task.id)}
-                          className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-xl transition-all duration-200"
+                          className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-all duration-200"
                         >
                           <MoreHorizontal size={20} />
                         </button>
                         {activeTaskMenu === task.id && (
-                          <div className="absolute right-0 top-12 bg-white border border-gray-200 rounded-2xl shadow-beautiful-lg py-2 z-10 min-w-[160px] animate-scale-in">
+                          <div className="absolute right-0 top-12 bg-white border border-gray-200 rounded-lg shadow-beautiful-lg py-2 z-10 min-w-[160px] animate-scale-in">
                             {task.scheduledTime && (
                               <button
                                 onClick={() => handleTaskAction(task.id, 'reschedule')}

--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Calendar, CheckCircle2, Circle, Timer, Waves, Clock, Play, Pause, CalendarDays } from 'lucide-react';
+import { Calendar, CheckCircle2, Circle, Timer, Waves, Play, Pause, CalendarDays } from 'lucide-react';
 import { Task, Settings } from '../types';
 
 interface ScheduleProps {
@@ -78,13 +78,13 @@ const Schedule: React.FC<ScheduleProps> = ({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-purple-50 to-pink-50">
+    <div className="min-h-screen bg-[#F4F6F8]">
       <div className="px-4 pt-8 pb-6">
         <div className="max-w-md mx-auto">
           {/* Beautiful Header */}
           <div className="mb-8 animate-fade-in">
             <div className="flex items-center space-x-3 mb-4">
-              <div className="p-3 bg-gradient-to-r from-purple-500 to-pink-500 rounded-2xl">
+              <div className="p-3 bg-gradient-to-r from-[#00C853] to-[#009624] rounded-lg">
                 <CalendarDays size={24} className="text-white" />
               </div>
               <div>
@@ -137,7 +137,7 @@ const Schedule: React.FC<ScheduleProps> = ({
                           .map((task, taskIndex) => (
                           <div
                             key={task.id}
-                            className={`rounded-2xl border transition-all duration-300 p-6 animate-slide-up ${getTaskStatusStyle(task)}`}
+                            className={`rounded-lg border transition-all duration-300 p-6 animate-slide-up ${getTaskStatusStyle(task)}`}
                             style={{ animationDelay: `${(dateIndex * 200) + (taskIndex * 100)}ms` }}
                           >
                             <div className="flex items-start space-x-4">
@@ -183,7 +183,7 @@ const Schedule: React.FC<ScheduleProps> = ({
                                       </button>
                                     ) : (
                                       <div className="flex items-center space-x-4">
-                                        <div className="flex items-center space-x-2 px-3 py-2 bg-blue-100 text-blue-700 rounded-xl font-semibold text-sm">
+                                        <div className="flex items-center space-x-2 px-3 py-2 bg-blue-100 text-blue-700 rounded-lg font-semibold text-sm">
                                           <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse-soft"></div>
                                           <span>Active Now</span>
                                         </div>
@@ -215,7 +215,7 @@ const Schedule: React.FC<ScheduleProps> = ({
                         {flexibleTasks.map((task, taskIndex) => (
                           <div
                             key={task.id}
-                            className={`rounded-2xl border transition-all duration-300 p-6 animate-slide-up ${getTaskStatusStyle(task)}`}
+                            className={`rounded-lg border transition-all duration-300 p-6 animate-slide-up ${getTaskStatusStyle(task)}`}
                             style={{ animationDelay: `${(dateIndex * 200) + (scheduledTasks.length * 100) + (taskIndex * 100)}ms` }}
                           >
                             <div className="flex items-start space-x-4">
@@ -261,7 +261,7 @@ const Schedule: React.FC<ScheduleProps> = ({
                                       </button>
                                     ) : (
                                       <div className="flex items-center space-x-4">
-                                        <div className="flex items-center space-x-2 px-3 py-2 bg-blue-100 text-blue-700 rounded-xl font-semibold text-sm">
+                                        <div className="flex items-center space-x-2 px-3 py-2 bg-blue-100 text-blue-700 rounded-lg font-semibold text-sm">
                                           <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse-soft"></div>
                                           <span>Active Now</span>
                                         </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -47,13 +47,13 @@ const SettingsPage: React.FC<SettingsProps> = ({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50">
+    <div className="min-h-screen bg-[#F4F6F8]">
       <div className="px-4 pt-8 pb-6">
         <div className="max-w-md mx-auto">
           {/* Beautiful Header */}
           <div className="mb-8 animate-fade-in">
             <div className="flex items-center space-x-3 mb-4">
-              <div className="p-3 bg-gradient-to-r from-indigo-500 to-purple-600 rounded-2xl">
+              <div className="p-3 bg-gradient-to-r from-[#007BFF] to-[#0056b3] rounded-lg">
                 <SettingsIcon size={24} className="text-white" />
               </div>
               <div>
@@ -123,15 +123,15 @@ const SettingsPage: React.FC<SettingsProps> = ({
 
                 <div>
                   <label className="form-label">Max Deep Work Hours Per Day</label>
-                  <select
+                  <input
+                    type="range"
+                    min={1}
+                    max={8}
                     value={settings.maxHoursPerDay}
                     onChange={(e) => handleMaxHoursChange(Number(e.target.value))}
-                    className="input-beautiful"
-                  >
-                    {[1, 2, 3, 4, 5, 6, 7, 8].map(hours => (
-                      <option key={hours} value={hours}>{hours} hour{hours !== 1 ? 's' : ''}</option>
-                    ))}
-                  </select>
+                    className="w-full"
+                  />
+                  <div className="text-sm font-semibold mt-1">{settings.maxHoursPerDay} h</div>
                   <p className="form-help">
                     Prevents over-scheduling and helps maintain sustainable productivity
                   </p>
@@ -139,15 +139,16 @@ const SettingsPage: React.FC<SettingsProps> = ({
 
                 <div>
                   <label className="form-label">Default Task Duration</label>
-                  <select
+                  <input
+                    type="range"
+                    min={15}
+                    max={120}
+                    step={5}
                     value={settings.defaultTaskDuration}
                     onChange={(e) => handleDefaultDurationChange(Number(e.target.value))}
-                    className="input-beautiful"
-                  >
-                    {[15, 25, 30, 45, 60, 90, 120].map(minutes => (
-                      <option key={minutes} value={minutes}>{minutes} minutes</option>
-                    ))}
-                  </select>
+                    className="w-full"
+                  />
+                  <div className="text-sm font-semibold mt-1">{settings.defaultTaskDuration} min</div>
                   <p className="form-help">
                     Used when no duration is specified in your task description
                   </p>
@@ -166,7 +167,7 @@ const SettingsPage: React.FC<SettingsProps> = ({
               
               <div className="form-section">
                 {/* Beautiful Auto Scheduling Toggle */}
-                <div className="flex items-center justify-between p-6 bg-gradient-to-r from-yellow-50 to-orange-50 rounded-2xl border border-yellow-200">
+                <div className="flex items-center justify-between p-6 bg-gradient-to-r from-yellow-50 to-orange-50 rounded-lg border border-yellow-200">
                   <div className="flex items-center space-x-4">
                     <div className="settings-icon bg-yellow-100">
                       <Zap size={20} className="text-yellow-600" />
@@ -208,9 +209,9 @@ const SettingsPage: React.FC<SettingsProps> = ({
                       <button
                         key={option.value}
                         onClick={() => handleTimeFormatChange(option.value as '12h' | '24h')}
-                        className={`p-6 rounded-2xl text-sm font-semibold transition-all duration-300 ${
+                        className={`p-6 rounded-lg text-sm font-semibold transition-all duration-300 ${
                           settings.timeFormat === option.value
-                            ? 'bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-beautiful-lg transform scale-105'
+                            ? 'bg-gradient-to-r from-[#007BFF] to-[#0056b3] text-white shadow-beautiful-lg transform scale-105'
                             : 'bg-gray-50 text-gray-700 border-2 border-gray-200 hover:border-gray-300 hover:shadow-beautiful'
                         }`}
                       >
@@ -231,7 +232,7 @@ const SettingsPage: React.FC<SettingsProps> = ({
                 </div>
                 <h2 className="text-xl font-bold text-gray-900">Data Management</h2>
               </div>
-              <div className="bg-gradient-to-r from-red-50 to-pink-50 border-2 border-red-200 rounded-2xl p-6">
+              <div className="bg-gradient-to-r from-red-50 to-pink-50 border-2 border-red-200 rounded-lg p-6">
                 <div className="flex items-center space-x-3 mb-4">
                   <RotateCcw size={20} className="text-red-600" />
                   <h3 className="font-bold text-red-900 text-lg">Reset All Data</h3>
@@ -241,7 +242,7 @@ const SettingsPage: React.FC<SettingsProps> = ({
                 </p>
                 <button
                   onClick={handleReset}
-                  className="w-full bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800 text-white py-4 px-6 rounded-2xl font-bold transition-all duration-300 shadow-beautiful hover:shadow-beautiful-lg transform hover:-translate-y-1"
+                  className="w-full bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800 text-white py-4 px-6 rounded-lg font-bold transition-all duration-300 shadow-beautiful hover:shadow-beautiful-lg transform hover:-translate-y-1"
                 >
                   <div className="flex items-center justify-center space-x-2">
                     <RotateCcw size={20} />
@@ -255,7 +256,7 @@ const SettingsPage: React.FC<SettingsProps> = ({
           {/* Beautiful App Info */}
           <div className="mt-8 text-center animate-slide-up" style={{ animationDelay: '500ms' }}>
             <div className="card-beautiful p-8">
-              <div className="w-16 h-16 bg-gradient-to-r from-blue-500 to-purple-600 rounded-2xl flex items-center justify-center mx-auto mb-6 animate-float">
+              <div className="w-16 h-16 bg-gradient-to-r from-[#007BFF] to-[#0056b3] rounded-lg flex items-center justify-center mx-auto mb-6 animate-float">
                 <SettingsIcon size={32} className="text-white" />
               </div>
               <h3 className="text-2xl font-bold text-gradient-primary mb-2">Focusly v2.0</h3>

--- a/src/components/Streaks.tsx
+++ b/src/components/Streaks.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flame, Target, TrendingUp, Award, Calendar, Trophy, Star, Zap } from 'lucide-react';
+import { Target, TrendingUp, Award, Calendar, Trophy, Star, Zap } from 'lucide-react';
 import { Task } from '../types';
 
 interface StreaksProps {
@@ -54,12 +54,12 @@ const Streaks: React.FC<StreaksProps> = ({ tasks }) => {
     const today = new Date().toDateString();
     const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toDateString();
 
-    let startDate = dates.includes(today) ? today : 
-                   dates.includes(yesterday) ? yesterday : null;
+    const startDate = dates.includes(today) ? today :
+                     dates.includes(yesterday) ? yesterday : null;
 
     if (!startDate) return 0;
 
-    let currentDate = new Date(startDate);
+    const currentDate = new Date(startDate);
     
     while (true) {
       const dateStr = currentDate.toDateString();
@@ -114,13 +114,13 @@ const Streaks: React.FC<StreaksProps> = ({ tasks }) => {
   const achievement = getAchievementLevel();
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-red-50 to-pink-50">
+    <div className="min-h-screen bg-[#F4F6F8]">
       <div className="px-4 pt-8 pb-6">
         <div className="max-w-md mx-auto">
           {/* Beautiful Header */}
           <div className="mb-8 animate-fade-in">
             <div className="flex items-center space-x-3 mb-4">
-              <div className="p-3 bg-gradient-to-r from-orange-500 to-red-500 rounded-2xl">
+              <div className="p-3 bg-gradient-to-r from-[#007BFF] to-[#0056b3] rounded-lg">
                 <TrendingUp size={24} className="text-white" />
               </div>
               <div>
@@ -132,7 +132,7 @@ const Streaks: React.FC<StreaksProps> = ({ tasks }) => {
 
           {/* Beautiful Current Streak */}
           <div className="mb-8 animate-scale-in">
-            <div className="bg-gradient-to-br from-orange-400 via-red-500 to-pink-500 rounded-3xl p-8 text-white shadow-beautiful-lg relative overflow-hidden">
+            <div className="bg-gradient-to-r from-[#00C853] to-[#009624] rounded-lg p-8 text-white shadow-beautiful-lg relative overflow-hidden">
               <div className="absolute top-0 right-0 w-32 h-32 bg-white/10 rounded-full -translate-y-16 translate-x-16"></div>
               <div className="absolute bottom-0 left-0 w-24 h-24 bg-white/10 rounded-full translate-y-12 -translate-x-12"></div>
               
@@ -165,9 +165,9 @@ const Streaks: React.FC<StreaksProps> = ({ tasks }) => {
           {/* Beautiful Achievement Badge */}
           {achievement && (
             <div className="mb-8 animate-bounce-gentle">
-              <div className={`bg-gradient-to-r ${achievement.color} rounded-3xl p-6 text-white shadow-beautiful-lg`}>
+              <div className={`bg-gradient-to-r ${achievement.color} rounded-lg p-6 text-white shadow-beautiful-lg`}>
                 <div className="flex items-center space-x-4">
-                  <div className="p-3 bg-white/20 rounded-2xl backdrop-blur-sm">
+                  <div className="p-3 bg-white/20 rounded-lg backdrop-blur-sm">
                     <achievement.icon size={32} className="text-white" />
                   </div>
                   <div>
@@ -186,7 +186,7 @@ const Streaks: React.FC<StreaksProps> = ({ tasks }) => {
           <div className="grid grid-cols-2 gap-4 mb-8">
             <div className="stats-card animate-slide-up" style={{ animationDelay: '100ms' }}>
               <div className="flex items-center space-x-3 mb-4">
-                <div className="p-2 bg-blue-100 rounded-xl">
+                <div className="p-2 bg-blue-100 rounded-lg">
                   <Target size={20} className="text-blue-600" />
                 </div>
                 <h3 className="font-bold text-gray-900">Today</h3>
@@ -200,7 +200,7 @@ const Streaks: React.FC<StreaksProps> = ({ tasks }) => {
 
             <div className="stats-card animate-slide-up" style={{ animationDelay: '200ms' }}>
               <div className="flex items-center space-x-3 mb-4">
-                <div className="p-2 bg-green-100 rounded-xl">
+                <div className="p-2 bg-green-100 rounded-lg">
                   <Calendar size={20} className="text-green-600" />
                 </div>
                 <h3 className="font-bold text-gray-900">This Week</h3>
@@ -218,7 +218,7 @@ const Streaks: React.FC<StreaksProps> = ({ tasks }) => {
             <div className="card-beautiful p-8">
               <div className="flex items-center justify-between mb-6">
                 <div className="flex items-center space-x-3">
-                  <div className="p-3 bg-purple-100 rounded-2xl">
+                  <div className="p-3 bg-purple-100 rounded-lg">
                     <TrendingUp size={24} className="text-purple-600" />
                   </div>
                   <h3 className="text-xl font-bold text-gray-900">Overall Progress</h3>
@@ -229,7 +229,7 @@ const Streaks: React.FC<StreaksProps> = ({ tasks }) => {
               </div>
               <div className="progress-beautiful mb-4">
                 <div 
-                  className="h-full rounded-full transition-all duration-1000 ease-out bg-gradient-to-r from-purple-500 to-blue-500"
+                  className="h-full rounded-full transition-all duration-1000 ease-out bg-gradient-to-r from-[#007BFF] to-[#0056b3]"
                   style={{ width: `${completionRate}%` }}
                 />
               </div>
@@ -249,8 +249,8 @@ const Streaks: React.FC<StreaksProps> = ({ tasks }) => {
 
           {/* Beautiful Motivational Message */}
           <div className="animate-slide-up" style={{ animationDelay: '400ms' }}>
-            <div className="bg-gradient-to-br from-indigo-50 to-purple-50 rounded-3xl p-8 text-center border border-indigo-100 shadow-beautiful">
-              <div className="w-16 h-16 bg-gradient-to-r from-indigo-500 to-purple-600 rounded-2xl flex items-center justify-center mx-auto mb-6 animate-float">
+            <div className="bg-[#F4F6F8] rounded-lg p-8 text-center border border-indigo-100 shadow-beautiful">
+              <div className="w-16 h-16 bg-gradient-to-r from-[#007BFF] to-[#0056b3] rounded-lg flex items-center justify-center mx-auto mb-6 animate-float">
                 <Star size={32} className="text-white" />
               </div>
               <h3 className="text-2xl font-bold text-gray-900 mb-4">

--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,7 @@
       sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+    background: #F4F6F8;
     min-height: 100vh;
   }
   
@@ -29,15 +29,15 @@
   
   /* Beautiful gradient backgrounds */
   .gradient-primary {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #007BFF 0%, #0056b3 100%);
   }
-  
+
   .gradient-secondary {
-    background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+    background: linear-gradient(135deg, #00C853 0%, #009624 100%);
   }
-  
+
   .gradient-success {
-    background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+    background: linear-gradient(135deg, #00C853 0%, #009624 100%);
   }
   
   .gradient-warning {
@@ -218,14 +218,14 @@ button:active:not(:disabled) {
 
 /* Beautiful text gradients */
 .text-gradient-primary {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, #007BFF 0%, #0056b3 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
 
 .text-gradient-secondary {
-  background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+  background: linear-gradient(135deg, #00C853 0%, #009624 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -240,8 +240,8 @@ button:active:not(:disabled) {
 
 /* Enhanced input styles */
 .input-beautiful {
-  @apply w-full px-4 py-3 bg-white border border-gray-200 rounded-2xl;
-  @apply focus:ring-2 focus:ring-blue-500 focus:border-transparent;
+  @apply w-full px-4 py-3 bg-white border border-gray-200 rounded-lg;
+  @apply focus:ring-2 focus:ring-[#007BFF] focus:border-transparent;
   @apply transition-all duration-300 ease-in-out;
   @apply shadow-sm hover:shadow-md;
 }
@@ -252,7 +252,7 @@ button:active:not(:disabled) {
 
 /* Enhanced card styles */
 .card-beautiful {
-  @apply bg-white rounded-3xl shadow-beautiful;
+  @apply bg-white rounded-lg shadow-beautiful;
   @apply border border-gray-100;
   @apply transition-all duration-300 ease-in-out;
 }
@@ -264,22 +264,22 @@ button:active:not(:disabled) {
 
 /* Enhanced button styles */
 .btn-primary {
-  @apply bg-gradient-to-r from-blue-600 to-blue-700;
-  @apply text-white font-semibold px-6 py-3 rounded-2xl;
+  @apply bg-gradient-to-r from-[#007BFF] to-[#0056b3];
+  @apply text-white font-semibold px-6 py-3 rounded-lg;
   @apply shadow-beautiful hover:shadow-beautiful-hover;
   @apply transition-all duration-300 ease-in-out;
 }
 
 .btn-secondary {
   @apply bg-gradient-to-r from-gray-100 to-gray-200;
-  @apply text-gray-700 font-semibold px-6 py-3 rounded-2xl;
+  @apply text-gray-700 font-semibold px-6 py-3 rounded-lg;
   @apply shadow-beautiful hover:shadow-beautiful-hover;
   @apply transition-all duration-300 ease-in-out;
 }
 
 .btn-success {
-  @apply bg-gradient-to-r from-green-500 to-green-600;
-  @apply text-white font-semibold px-6 py-3 rounded-2xl;
+  @apply bg-gradient-to-r from-[#00C853] to-[#009624];
+  @apply text-white font-semibold px-6 py-3 rounded-lg;
   @apply shadow-beautiful hover:shadow-beautiful-hover;
   @apply transition-all duration-300 ease-in-out;
 }
@@ -292,7 +292,7 @@ button:active:not(:disabled) {
 
 .progress-fill {
   @apply h-full rounded-full transition-all duration-500 ease-out;
-  @apply bg-gradient-to-r from-blue-500 to-blue-600;
+  @apply bg-gradient-to-r from-[#007BFF] to-[#0056b3];
 }
 
 /* Enhanced status indicators */
@@ -303,7 +303,7 @@ button:active:not(:disabled) {
 .status-active::before {
   content: '';
   @apply absolute -left-1 top-1/2 transform -translate-y-1/2;
-  @apply w-2 h-2 bg-blue-500 rounded-full;
+  @apply w-2 h-2 bg-[#007BFF] rounded-full;
   animation: pulseSoft 2s ease-in-out infinite;
 }
 
@@ -406,7 +406,7 @@ button:active:not(:disabled) {
 
 /* Enhanced settings sections */
 .settings-section {
-  @apply bg-white rounded-3xl p-6;
+  @apply bg-white rounded-lg p-6;
   @apply shadow-beautiful border border-gray-100;
   @apply space-y-4;
 }
@@ -447,7 +447,7 @@ button:active:not(:disabled) {
 
 /* Enhanced stats cards */
 .stats-card {
-  @apply bg-white rounded-2xl p-5;
+  @apply bg-white rounded-lg p-5;
   @apply shadow-beautiful border border-gray-100;
   @apply transition-all duration-300 ease-in-out;
   @apply hover:shadow-beautiful-hover;
@@ -464,19 +464,19 @@ button:active:not(:disabled) {
 /* Enhanced notification styles */
 .notification-success {
   @apply bg-green-50 border border-green-200 text-green-800;
-  @apply px-4 py-3 rounded-2xl;
+  @apply px-4 py-3 rounded-lg;
   @apply shadow-beautiful;
 }
 
 .notification-error {
   @apply bg-red-50 border border-red-200 text-red-800;
-  @apply px-4 py-3 rounded-2xl;
+  @apply px-4 py-3 rounded-lg;
   @apply shadow-beautiful;
 }
 
 .notification-warning {
   @apply bg-yellow-50 border border-yellow-200 text-yellow-800;
-  @apply px-4 py-3 rounded-2xl;
+  @apply px-4 py-3 rounded-lg;
   @apply shadow-beautiful;
 }
 


### PR DESCRIPTION
## Summary
- switch to a neutral color palette and modern button styles
- trim border radius for a cleaner aesthetic
- add text-based **Add Task** button and input hint
- show milestone lines on progress bar
- make Settings sliders more interactive

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f048033cc8333bf3a241f7b291344