### PR TITLE
Fix missing Plus icon import

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,19 @@
 import React, { useState } from 'react';
-import { CheckCircle2, Circle, Clock, Timer, Waves, MoreHorizontal, Trash2, RotateCcw, Play, Pause, Sparkles, Target } from 'lucide-react';
+import {
+  CheckCircle2,
+  Circle,
+  Clock,
+  Timer,
+  Waves,
+  MoreHorizontal,
+  Trash2,
+  RotateCcw,
+  Play,
+  Pause,
+  Sparkles,
+  Target,
+  Plus
+} from 'lucide-react';
 import { Task, Settings } from '../types';
 
 interface DashboardProps {


### PR DESCRIPTION
## Summary
- fix the `Plus` icon reference by importing it in `Dashboard`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f0a616fb48333bb94f27565a9b5c5