### PR TITLE
Fix runtime errors and add missing types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Home, Calendar, Flame, Settings } from 'lucide-react';
 import Dashboard from './components/Dashboard';
 import Schedule from './components/Schedule';

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { CheckCircle2, Circle, Clock, Timer, Waves, MoreHorizontal, Trash2, RotateCcw, Play, Pause, Sparkles, Target } from 'lucide-react';
+import { CheckCircle2, Circle, Clock, Timer, Waves, MoreHorizontal, Trash2, RotateCcw, Play, Pause, Sparkles, Target, Plus } from 'lucide-react';
 import { Task, Settings } from '../types';
 
 interface DashboardProps {

--- a/src/components/Streaks.tsx
+++ b/src/components/Streaks.tsx
@@ -112,6 +112,7 @@ const Streaks: React.FC<StreaksProps> = ({ tasks }) => {
   };
 
   const achievement = getAchievementLevel();
+  const AchievementIcon = achievement?.icon;
 
   return (
     <div className="min-h-screen bg-[#F4F6F8]">
@@ -168,7 +169,9 @@ const Streaks: React.FC<StreaksProps> = ({ tasks }) => {
               <div className={`bg-gradient-to-r ${achievement.color} rounded-lg p-6 text-white shadow-beautiful-lg`}>
                 <div className="flex items-center space-x-4">
                   <div className="p-3 bg-white/20 rounded-lg backdrop-blur-sm">
-                    <achievement.icon size={32} className="text-white" />
+                    {AchievementIcon && (
+                      <AchievementIcon size={32} className="text-white" />
+                    )}
                   </div>
                   <div>
                     <h3 className="text-xl font-bold text-white mb-1">Achievement Unlocked!</h3>

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,16 @@ export interface Task {
   createdAt: string;
 }
 
+export interface Goal {
+  id: string;
+  title: string;
+  frequency: number; // times per week
+  duration: number; // minutes
+  color: string;
+  streak: number;
+  createdAt: string;
+}
+
 export interface Settings {
   focusHours: {
     start: string; // "08:00"


### PR DESCRIPTION
## Summary
- add missing `Plus` icon import in `Dashboard`
- handle dynamic icons in `Streaks` component properly
- remove unused `React` default import
- add `Goal` interface

## Testing
- `npm run build`
- `npm run lint`
- `npx tsc -p tsconfig.app.json`


------
https://chatgpt.com/codex/tasks/task_e_684f0a3b978c8333a8daa06923336708