### PR TITLE
Refine task card theme and remove leftovers

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -142,7 +142,7 @@ const Dashboard: React.FC<DashboardProps> = ({
 
           {/* Beautiful Task Input */}
           <div className="mb-8 animate-slide-up">
-            <div className="card-beautiful p-8">
+            <div className="card-beautiful rounded-xl shadow-md hover:shadow-lg transition-all p-6 sm:p-8">
               <div className="flex items-center space-x-3 mb-6">
                 <div className="p-2 bg-gradient-to-r from-[#ff7e5f] to-[#feb47b] rounded-full">
                   <Plus size={20} className="text-white" />
@@ -153,20 +153,20 @@ const Dashboard: React.FC<DashboardProps> = ({
               </div>
               
               <form onSubmit={handleSubmit} className="space-y-6">
-                <div className="flex items-center space-x-4">
+                <div className="flex items-center space-x-3">
                   <label className="flex items-center space-x-3 cursor-pointer group">
                     <input
                       type="checkbox"
                       checked={isTimedTask}
                       onChange={(e) => setIsTimedTask(e.target.checked)}
-                      className="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 transition-colors duration-200"
+                      className="w-5 h-5 rounded border-gray-300 text-orange-500 focus:ring-orange-500 focus:outline-none transition-colors duration-200"
                     />
                     <div className="flex items-center space-x-2">
-                      <Timer size={18} className="text-blue-600 group-hover:text-blue-700 transition-colors duration-200" />
+                      <Timer size={18} className="text-orange-500 group-hover:text-orange-600 transition-colors duration-200" />
                       <span className="text-gray-700 font-medium group-hover:text-gray-900 transition-colors duration-200">
                         Make this a timed task
                       </span>
-                      <Info size={16} className="text-gray-500" title="Timed tasks are scheduled automatically. Uncheck to keep flexible." />
+                      <Info size={16} className="text-gray-500" title="Timed tasks will be scheduled automatically in your daily focus window" />
                     </div>
                   </label>
                 </div>
@@ -176,20 +176,22 @@ const Dashboard: React.FC<DashboardProps> = ({
                     type="text"
                     value={taskInput}
                     onChange={(e) => setTaskInput(e.target.value)}
-                    placeholder="Finish Homework..."
-                    className="input-beautiful text-base pr-16 h-12 placeholder-gray-600"
+                    placeholder="e.g. Finish homework (45)"
+                    className="input-beautiful text-base pr-16 h-12 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-500"
                     autoFocus
                   />
                   <button
-                    type="submit"
+                    type="button"
+                    aria-label="Add Task"
+                    onClick={handleSubmit}
                     disabled={!taskInput.trim()}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 transform p-2 h-10 bg-gradient-to-r from-[#ff7e5f] to-[#feb47b] text-white rounded-lg hover:shadow-beautiful disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 transform p-2 h-10 bg-orange-500 text-white rounded-lg hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-orange-300 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300"
                   >
                     <Plus size={20} />
                   </button>
                 </div>
-                <p className="text-xs text-gray-500">Press Enter to add</p>
-                <p className="text-xs text-gray-500">Tip: include the number of minutes in parentheses</p>
+                <p className="text-sm text-gray-500">Press Enter to add</p>
+                <p className="text-sm text-gray-500">Tip: include the number of minutes in parentheses</p>
               </form>
             </div>
           </div>
@@ -276,9 +278,9 @@ const Dashboard: React.FC<DashboardProps> = ({
                   .map((task, index) => (
                   <div
                     key={task.id}
-                    className={`card-beautiful p-6 transition-all duration-300 relative animate-slide-up ${
-                      task.completed 
-                        ? 'bg-gradient-purple-soft border-purple-200'
+                    className={`card-beautiful p-6 transition-all duration-300 relative animate-slide-up animate-scale-in ${
+                      task.completed
+                        ? 'bg-gradient-orange-soft border-orange-200'
                         : task.status === 'active'
                         ? 'bg-gradient-blue-soft border-blue-200 shadow-beautiful-lg'
                         : 'hover:shadow-beautiful-hover'
@@ -290,9 +292,9 @@ const Dashboard: React.FC<DashboardProps> = ({
                         onClick={() => onToggleTask(task.id)}
                         className="mt-1 transition-all duration-300 hover:scale-110"
                       >
-                        {task.completed ? (
-                          <CheckCircle2 size={24} className="text-purple-600" />
-                        ) : (
+                          {task.completed ? (
+                            <CheckCircle2 size={24} className="text-orange-600" />
+                          ) : (
                           <Circle size={24} className="text-gray-400 hover:text-gray-600" />
                         )}
                       </button>
@@ -319,7 +321,7 @@ const Dashboard: React.FC<DashboardProps> = ({
                             {task.isTimedTask ? (
                               <Timer size={16} className="text-blue-500" />
                             ) : (
-                              <Waves size={16} className="text-purple-500" />
+                              <Waves size={16} className="text-orange-500" />
                             )}
                           </div>
                           {task.status === 'active' && (

--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -63,7 +63,7 @@ const Schedule: React.FC<ScheduleProps> = ({
   };
 
   const getTaskStatusStyle = (task: Task) => {
-    if (task.completed) return 'bg-gradient-purple-soft border-purple-200';
+    if (task.completed) return 'bg-gradient-orange-soft border-orange-200';
     if (task.status === 'active') return 'bg-gradient-blue-soft border-blue-200 shadow-beautiful-lg';
     return 'bg-white border-gray-100 hover:shadow-beautiful-hover';
   };
@@ -145,9 +145,9 @@ const Schedule: React.FC<ScheduleProps> = ({
                                 onClick={() => onToggleTask(task.id)}
                                 className="mt-1 transition-all duration-300 hover:scale-110"
                               >
-                                {task.completed ? (
-                                  <CheckCircle2 size={24} className="text-purple-600" />
-                                ) : (
+                                  {task.completed ? (
+                                    <CheckCircle2 size={24} className="text-orange-600" />
+                                  ) : (
                                   <Circle size={24} className="text-gray-400 hover:text-gray-600" />
                                 )}
                               </button>
@@ -209,8 +209,8 @@ const Schedule: React.FC<ScheduleProps> = ({
                     {flexibleTasks.length > 0 && (
                       <div className="space-y-4">
                         <div className="flex items-center space-x-2 mb-4">
-                          <Waves size={18} className="text-purple-600" />
-                          <h3 className="text-lg font-bold text-purple-900">Flexible Tasks</h3>
+                          <Waves size={18} className="text-orange-600" />
+                          <h3 className="text-lg font-bold text-orange-900">Flexible Tasks</h3>
                         </div>
                         {flexibleTasks.map((task, taskIndex) => (
                           <div
@@ -223,9 +223,9 @@ const Schedule: React.FC<ScheduleProps> = ({
                                 onClick={() => onToggleTask(task.id)}
                                 className="mt-1 transition-all duration-300 hover:scale-110"
                               >
-                                {task.completed ? (
-                                  <CheckCircle2 size={24} className="text-purple-600" />
-                                ) : (
+                                  {task.completed ? (
+                                    <CheckCircle2 size={24} className="text-orange-600" />
+                                  ) : (
                                   <Circle size={24} className="text-gray-400 hover:text-gray-600" />
                                 )}
                               </button>
@@ -242,7 +242,7 @@ const Schedule: React.FC<ScheduleProps> = ({
                                   <span className="time-display text-gray-600">
                                     {task.duration} min
                                   </span>
-                                  <Waves size={16} className="text-purple-500" />
+                                  <Waves size={16} className="text-orange-500" />
                                   {task.status === 'active' && (
                                     <div className="status-active flex items-center space-x-2 text-blue-600 font-semibold text-sm">
                                       <span>Active</span>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -93,8 +93,8 @@ const SettingsPage: React.FC<SettingsProps> = ({
             {/* Beautiful Focus Settings */}
             <div className="settings-section animate-slide-up" style={{ animationDelay: '200ms' }}>
               <div className="settings-header">
-                <div className="settings-icon bg-purple-100">
-                  <Clock size={20} className="text-purple-600" />
+                <div className="settings-icon bg-orange-100">
+                  <Clock size={20} className="text-orange-600" />
                 </div>
                 <h2 className="text-xl font-bold text-gray-900">Focus Hours</h2>
               </div>
@@ -159,8 +159,8 @@ const SettingsPage: React.FC<SettingsProps> = ({
             {/* Beautiful Preferences */}
             <div className="settings-section animate-slide-up" style={{ animationDelay: '300ms' }}>
               <div className="settings-header">
-                <div className="settings-icon bg-purple-100">
-                  <Palette size={20} className="text-purple-600" />
+                <div className="settings-icon bg-orange-100">
+                  <Palette size={20} className="text-orange-600" />
                 </div>
                 <h2 className="text-xl font-bold text-gray-900">Preferences</h2>
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -44,9 +44,6 @@
     background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
   }
   
-  .gradient-purple {
-    background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
-  }
   
   .gradient-blue-soft {
     background: linear-gradient(135deg, #e0f2fe 0%, #f0f9ff 100%);
@@ -56,9 +53,6 @@
     background: linear-gradient(135deg, #fff7ed 0%, #ffedd5 100%);
   }
   
-  .gradient-purple-soft {
-    background: linear-gradient(135deg, #f5f3ff 0%, #ede9fe 100%);
-  }
   
   /* Glass morphism effects */
   .glass {
@@ -380,13 +374,13 @@ button:active:not(:disabled) {
 
 .task-type-flexible {
   @apply inline-flex items-center px-2 py-1;
-  @apply bg-purple-100 text-purple-700 text-xs font-medium rounded-lg;
+  @apply bg-orange-100 text-orange-700 text-xs font-medium rounded-lg;
 }
 
 /* Enhanced completion states */
 .task-completed {
   @apply opacity-75 line-through;
-  @apply text-purple-600;
+  @apply text-orange-600;
 }
 
 /* Enhanced priority indicators */
@@ -399,7 +393,7 @@ button:active:not(:disabled) {
 }
 
 .priority-low {
-  @apply border-l-4 border-purple-500;
+  @apply border-l-4 border-orange-500;
 }
 
 /* Enhanced time displays */
@@ -467,7 +461,7 @@ button:active:not(:disabled) {
 
 /* Enhanced notification styles */
 .notification-success {
-  @apply bg-purple-50 border border-purple-200 text-purple-800;
+  @apply bg-orange-50 border border-orange-200 text-orange-800;
   @apply px-4 py-3 rounded-lg;
   @apply shadow-beautiful;
 }


### PR DESCRIPTION
## Summary
- make completed task styling use the orange theme
- adjust mobile task input card with centered add button and accessible tooltip
- remove unused purple gradient classes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f23c4e5848333a245e23b899c587d