### PR TITLE
Refine dashboard input and theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,10 +225,10 @@ function App() {
       <nav className="nav-beautiful px-6 py-4 safe-area-pb">
         <div className="flex justify-around items-center max-w-md mx-auto">
           {[
-            { id: 'dashboard', icon: Home, label: 'Today', gradient: 'from-[#007BFF] to-[#0056b3]' },
-            { id: 'schedule', icon: Calendar, label: 'Schedule', gradient: 'from-[#007BFF] to-[#0056b3]' },
-            { id: 'streaks', icon: Flame, label: 'Progress', gradient: 'from-[#007BFF] to-[#0056b3]' },
-            { id: 'settings', icon: Settings, label: 'Settings', gradient: 'from-[#007BFF] to-[#0056b3]' }
+            { id: 'dashboard', icon: Home, label: 'Today', gradient: 'from-[#1a1a1a] to-[#000000]' },
+            { id: 'schedule', icon: Calendar, label: 'Schedule', gradient: 'from-[#1a1a1a] to-[#000000]' },
+            { id: 'streaks', icon: Flame, label: 'Progress', gradient: 'from-[#1a1a1a] to-[#000000]' },
+            { id: 'settings', icon: Settings, label: 'Settings', gradient: 'from-[#1a1a1a] to-[#000000]' }
           ].map(({ id, icon: Icon, label, gradient }) => (
             <button
               key={id}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -177,7 +177,7 @@ const Dashboard: React.FC<DashboardProps> = ({
                     value={taskInput}
                     onChange={(e) => setTaskInput(e.target.value)}
                     placeholder="e.g. Finish homework (45)"
-                    className="input-beautiful text-base pr-16 h-12 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-500"
+                    className="input-beautiful text-base pr-16 h-12 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-black"
                     autoFocus
                   />
                   <button
@@ -185,13 +185,13 @@ const Dashboard: React.FC<DashboardProps> = ({
                     aria-label="Add Task"
                     onClick={handleSubmit}
                     disabled={!taskInput.trim()}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 transform p-2 h-10 bg-orange-500 text-white rounded-lg hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-orange-300 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 transform p-2 h-10 bg-orange-500 text-white rounded-lg hover:bg-orange-600 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-orange-300 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300"
                   >
                     <Plus size={20} />
                   </button>
                 </div>
-                <p className="text-sm text-gray-500">Press Enter to add</p>
-                <p className="text-sm text-gray-500">Tip: include the number of minutes in parentheses</p>
+                <p className="text-sm text-muted-foreground">Press Enter to add</p>
+                <p className="text-sm text-muted-foreground">Tip: include the number of minutes in parentheses</p>
               </form>
             </div>
           </div>
@@ -199,7 +199,7 @@ const Dashboard: React.FC<DashboardProps> = ({
           {/* Beautiful Active Task Widget */}
           {currentActiveTask && (
             <div className="mb-8 animate-scale-in">
-              <div className="bg-gradient-to-r from-[#007BFF] to-[#0056b3] rounded-lg p-6 text-white shadow-beautiful-lg">
+              <div className="bg-gradient-to-r from-[#1a1a1a] to-[#000000] rounded-lg p-6 text-white shadow-beautiful-lg">
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center space-x-3">
                     <div className="w-3 h-3 bg-white rounded-full animate-pulse-soft"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -8,12 +8,12 @@
   }
   
   body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-      sans-serif;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+      'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+      'Helvetica Neue', sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    background: #F4F6F8;
+    background: #f5f5f5;
     min-height: 100vh;
   }
   
@@ -29,7 +29,7 @@
   
   /* Beautiful gradient backgrounds */
   .gradient-primary {
-    background: linear-gradient(135deg, #007BFF 0%, #0056b3 100%);
+    background: linear-gradient(135deg, #1a1a1a 0%, #000000 100%);
   }
 
   .gradient-secondary {
@@ -218,7 +218,7 @@ button:active:not(:disabled) {
 
 /* Beautiful text gradients */
 .text-gradient-primary {
-  background: linear-gradient(135deg, #007BFF 0%, #0056b3 100%);
+  background: linear-gradient(135deg, #1a1a1a 0%, #000000 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -242,7 +242,7 @@ button:active:not(:disabled) {
 /* Enhanced input styles */
 .input-beautiful {
   @apply w-full px-4 py-3 bg-white border border-gray-200 rounded-lg;
-  @apply focus:ring-2 focus:ring-[#007BFF] focus:border-transparent;
+  @apply focus:ring-2 focus:ring-black focus:border-transparent;
   @apply transition-all duration-300 ease-in-out;
   @apply shadow-sm hover:shadow-md;
 }
@@ -265,18 +265,16 @@ button:active:not(:disabled) {
 
 /* Enhanced button styles */
 .btn-primary {
-  @apply bg-gradient-to-r from-[#007BFF] to-[#0056b3];
-  @apply text-white font-semibold px-6 py-3 rounded-lg;
+  @apply bg-black text-white font-semibold px-6 py-3 rounded-lg;
   @apply min-h-[44px];
-  @apply shadow-beautiful hover:shadow-beautiful-hover;
+  @apply shadow-beautiful hover:shadow-beautiful-hover hover:bg-gray-800;
   @apply transition-all duration-300 ease-in-out active:scale-95;
 }
 
 .btn-secondary {
-  @apply bg-gradient-to-r from-gray-100 to-gray-200;
-  @apply text-gray-700 font-semibold px-6 py-3 rounded-lg;
+  @apply bg-gray-100 text-gray-800 font-semibold px-6 py-3 rounded-lg;
   @apply min-h-[44px];
-  @apply shadow-beautiful hover:shadow-beautiful-hover;
+  @apply shadow-beautiful hover:shadow-beautiful-hover hover:bg-gray-200;
   @apply transition-all duration-300 ease-in-out active:scale-95;
 }
 
@@ -307,7 +305,7 @@ button:active:not(:disabled) {
 .status-active::before {
   content: '';
   @apply absolute -left-1 top-1/2 transform -translate-y-1/2;
-  @apply w-2 h-2 bg-[#007BFF] rounded-full;
+  @apply w-2 h-2 bg-black rounded-full;
   animation: pulseSoft 2s ease-in-out infinite;
 }
 
@@ -447,6 +445,11 @@ button:active:not(:disabled) {
 
 .form-help {
   @apply text-xs text-gray-500 mt-1;
+}
+
+/* Muted text color */
+.text-muted-foreground {
+  @apply text-gray-500;
 }
 
 /* Enhanced stats cards */


### PR DESCRIPTION
## Summary
- adjust body font and background for a Notion‑like feel
- simplify button styles for a neutral palette
- refine task input layout and colors
- update navigation gradient colors

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f31ab73a883338e6f0b531e61b965